### PR TITLE
fix a bug with incorrect results if last_row in rows

### DIFF
--- a/piccolo_cursor_pagination/pagination.py
+++ b/piccolo_cursor_pagination/pagination.py
@@ -73,7 +73,7 @@ class CursorPagination:
                 # set new value to next_cursor
                 next_cursor = self.encode_cursor(str(rows[-1]["id"]))
                 headers["cursor"] = next_cursor
-                # if the last_row of whole data tset is in rows, it means that
+                # if the last_row of whole data set is in rows, it means that
                 # there are no more results, then we must use the first item
                 # in the rows to get the correct result of the previous rows
                 last_row = await (

--- a/tests/test_cursor_pagination_asc.py
+++ b/tests/test_cursor_pagination_asc.py
@@ -79,7 +79,7 @@ class TestCursorPaginationAsc(TestCase):
         client = TestClient(app)
         response = client.get("/movies/", params={"__cursor": ""})
         self.assertTrue(response.status_code, 200)
-        self.assertEqual(response.headers["next_cursor"], "Mg==")
+        self.assertEqual(response.headers["next_cursor"], "MQ==")
         self.assertEqual(
             response.json(),
             {

--- a/tests/test_cursor_pagination_desc.py
+++ b/tests/test_cursor_pagination_desc.py
@@ -83,7 +83,7 @@ class TestCursorPaginationAsc(TestCase):
         client = TestClient(app)
         response = client.get("/movies/", params={"__cursor": ""})
         self.assertTrue(response.status_code, 200)
-        self.assertEqual(response.headers["next_cursor"], "MQ==")
+        self.assertEqual(response.headers["next_cursor"], "Mg==")
         self.assertEqual(
             response.json(),
             {


### PR DESCRIPTION
There is a bug and with this PR we fixing situation if the `last_row` of the whole data set is in rows, it means that there are no more results, then we have to use the first item in rows to get the correct result of the previous rows. Previously we use last item in rows (rows result which contains `last_row`) which result incorrect data if we gone backwards.